### PR TITLE
Authorize.Net: Update to new Akamai URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ pkg
 Gemfile.lock
 Gemfile*.lock
 .rbx/
+*.DS_Store
 *.swp
+tags

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -29,10 +29,10 @@ module ActiveMerchant #:nodoc:
       class_attribute :arb_test_url, :arb_live_url
 
       self.test_url = "https://test.authorize.net/gateway/transact.dll"
-      self.live_url = "https://secure.authorize.net/gateway/transact.dll"
+      self.live_url = "https://secure2.authorize.net/gateway/transact.dll"
 
       self.arb_test_url = 'https://apitest.authorize.net/xml/v1/request.api'
-      self.arb_live_url = 'https://api.authorize.net/xml/v1/request.api'
+      self.arb_live_url = 'https://api2.authorize.net/xml/v1/request.api'
       self.ssl_version = :TLSv1
       class_attribute :duplicate_window
 


### PR DESCRIPTION
Move to [Akamai SureRoute](https://www.authorize.net/support/akamaifaqs/#akamai) to take advantage of the uptime benefits Akamai SureRoute offers and provide better platform reliability.

Please refer to [AuthorizeNet Announcement](https://www.authorize.net/support/akamaifaqs)

More tests on live mode should be done before go alive.
