### PR TITLE
add response format to AuthorizeNet gateway so that the api call can get consistent response format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg
 Gemfile.lock
 Gemfile*.lock
 .rbx/
+*.swp

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -319,15 +319,16 @@ module ActiveMerchant #:nodoc:
       def post_data(action, parameters = {})
         post = {}
 
-        post[:version]        = API_VERSION
-        post[:login]          = @options[:login]
-        post[:tran_key]       = @options[:password]
-        post[:relay_response] = "FALSE"
-        post[:type]           = action
-        post[:delim_data]     = "TRUE"
-        post[:delim_char]     = ","
-        post[:encap_char]     = "$"
-        post[:solution_ID]    = application_id if application_id.present? && application_id != "ActiveMerchant"
+        post[:version]         = API_VERSION
+        post[:login]           = @options[:login]
+        post[:tran_key]        = @options[:password]
+        post[:relay_response]  = "FALSE"
+        post[:type]            = action
+        post[:delim_data]      = "TRUE"
+        post[:delim_char]      = ","
+        post[:encap_char]      = "$"
+        post[:response_format] = 2
+        post[:solution_ID]     = application_id if application_id.present? && application_id != "ActiveMerchant"
 
         request = post.merge(parameters).
           reject {|key, value| value.nil? || value == ""}.

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -441,7 +441,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   private
   def post_data_fixture
-    'x_encap_char=%24&x_card_num=4242424242424242&x_exp_date=0806&x_card_code=123&x_type=AUTH_ONLY&x_first_name=Longbob&x_version=3.1&x_login=X&x_last_name=Longsen&x_tran_key=Y&x_relay_response=FALSE&x_delim_data=TRUE&x_delim_char=%2C&x_amount=1.01'
+    'x_encap_char=%24&x_card_num=4242424242424242&x_exp_date=0806&x_card_code=123&x_type=AUTH_ONLY&x_first_name=Longbob&x_version=3.1&x_login=X&x_last_name=Longsen&x_tran_key=Y&x_relay_response=FALSE&x_delim_data=TRUE&x_delim_char=%2C&x_amount=1.01&x_response_format=2'
   end
 
   def minimum_requirements


### PR DESCRIPTION
According to the [Authorize.net API documentation](http://www.authorize.net/content/dam/authorize/documents/AIM_guide.pdf)

> x_response_format Value: Set to 2. The 0 and 1 values are now deprecated.
> Note: This field overrides the default response format.
> 
> x_response_format
> 0: xml
> 1: delimited string starting with Version
> 2: delimited string starting with Response Code

But we found that if the account type is Card Present the default response format is 1 rather than 2. This was causing inconsistent response format but ActiveMerchant was not aware of that. Instead it used the version number(always be 1.0) as the response code(1: success, 3: error).

This PR adds the x_response_format params into the api call and forces the response string starting with response code, so that ActiveMerchant can parse the response correctly.
